### PR TITLE
Fix typoscript code block formatting

### DIFF
--- a/Documentation/Exceptions/1540246570.rst
+++ b/Documentation/Exceptions/1540246570.rst
@@ -22,10 +22,8 @@ f.e. you have used this:
 ::
 
      [globalVar = TSFE:id = {$noLoginPluginOnPids}]
-
-lib.login >
-
-::
+     
+     lib.login >
 
      [global]
 
@@ -42,9 +40,7 @@ change typoscript to:
 
      [globalVar = TSFE:id = {$noLoginPluginOnPids}]
 
-lib.login =
-
-::
+     lib.login =
 
      [global]
 


### PR DESCRIPTION
Place all three lines in one typoscript codeblock, as it's meant to be in one block.