### PR TITLE
[BUGFIX] Replace code block

### DIFF
--- a/Documentation/Exceptions/1278155988.rst
+++ b/Documentation/Exceptions/1278155988.rst
@@ -10,12 +10,23 @@ Broken character in locallang files
 ====================================
 
 This exception happens if you have invalid characters in a `locallang.xlf` file.
-For example
 
-.. code-block: xml
+_Example_
+
+Bad:
+
+.. code-block:: xml
 
    <trans-unit >
     <source>Bootstrap Package: Left & normal, 2 Columns</source>
    </trans-unit>
 
-Make sure to use `CDATA` to escape special characters.
+Good:
+
+Wrap with `CDATA` to escape special characters.
+
+.. code-block:: xml
+
+   <trans-unit >
+    <source><![CDATA[Bootstrap Package: Left & normal, 2 Columns]]></source>
+   </trans-unit>


### PR DESCRIPTION
Example code was not shown in HTML view, due to wrong Rest code block.

See https://docs.typo3.org/typo3cms/exceptions/master/en-us/Exceptions/1278155988.html