### PR TITLE
Update 1328709784.rst

### DIFF
--- a/Documentation/Exceptions/1328709784.rst
+++ b/Documentation/Exceptions/1328709784.rst
@@ -21,3 +21,5 @@ section:
 
 And that yaml is loaded to the plugin and/or module form settings:  
 :typoscript:`plugin.tx_form.settings.yamlConfigurations`  
+
+It could also be the case that you correctly registered the finisher in the base config of your form setup (e.g. in the root template of your site) but the registration will not work because there might be a syntax error in the typoscript (e.g. a missing closing curly brace from an open code-block); in that case, the registration will not succeed and hence, the form framework is not able to find the finisher. This will most likely happen during a major upgrade of TYPO3 when there are typically bigger changes in your typoscript setup.


### PR DESCRIPTION
Adds a hint why the exception #1328709784 might be raised. It cost me half a day to find out that there's actually no syntax check when typoscript is being changed in the backend and that it will simply be executed until the interpreter finds a syntax error. 👎 (in my case, the added registration of the finisher in the typoscript code was not executed due to that reason)

So this is a prime example why the fail-fast-pattern should be followed ;-)