### PR TITLE
Vendor prefix is not required anymore in ExtensionUtility::configurePlugin()

### DIFF
--- a/Documentation/Exceptions/1316104317.rst
+++ b/Documentation/Exceptions/1316104317.rst
@@ -20,7 +20,7 @@ controller/action. Here's an example:
 
    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
      //assuming your extension is in typo3conf/ext/your_ext folder
-     'YourVendor.YourExt',
+     'YourExt',
 
      // Plugin name
      'Pi1',


### PR DESCRIPTION
See Deprecation: #87550 - Use controller classes when registering plugins/modules