### PR TITLE
Refer to PHP version with opcache.load_comments

### DIFF
--- a/Documentation/Exceptions/1242292003.rst
+++ b/Documentation/Exceptions/1242292003.rst
@@ -32,7 +32,7 @@ data type.
 #. use another PHP optimizer. I use xCache on Debian Squeeze which seems
    to work fine.
 #. using the opcode cache of modern PHP versions, you can set
-   opcache.save_comments=1 and opcache.load_comments=1.
+   opcache.save_comments=1.
 
 Links:
 

--- a/Documentation/Exceptions/1242292003.rst
+++ b/Documentation/Exceptions/1242292003.rst
@@ -32,7 +32,7 @@ data type.
 #. use another PHP optimizer. I use xCache on Debian Squeeze which seems
    to work fine.
 #. using the opcode cache of modern PHP versions, you can set
-   opcache.save_comments=1.
+   opcache.save_comments=1 (and opcache.load_comments=1 in PHP < 7.0).
 
 Links:
 


### PR DESCRIPTION
The configuration setting opcache.load_comments is no longer used in PHP. However, opcache.save_comments still is.

We now mention the PHP version when it was dropped to make it more clear.

> Removed opcache.load_comments configuration directive. Now doc
> comments loading costs nothing and always enabled.

https://prototype.php.net/versions/7.0.0/