### PR TITLE
Corrected the exception's description.

### DIFF
--- a/Documentation/Exceptions/1314778269.rst
+++ b/Documentation/Exceptions/1314778269.rst
@@ -15,8 +15,6 @@ FAL: addFile()
 Error when adding a :sql:`sys_file` to a FAL storage
 via `$this->storage->addFile($localFilePath, $targetFolder, $targetFileName)`:
 
-The problem was that the first parameter `$localFilePath` was an absolute
-path instead of a relative path.
-
--  Wrong: :file:`my/absolute/path/www/fileadmin/myfile.jpg`
--  Correct: :file:`fileadmin/myfile.jpg`
+The exception is thrown when the `$localFilePath` (the source file) is already located anywhere
+inside of the target's FAL local storage path. For example inside of :file:`fileadmin/` when using the dafault
+local storage.

--- a/Documentation/Exceptions/1314778269.rst
+++ b/Documentation/Exceptions/1314778269.rst
@@ -16,5 +16,5 @@ Error when adding a :sql:`sys_file` to a FAL storage
 via `$this->storage->addFile($localFilePath, $targetFolder, $targetFileName)`:
 
 The exception is thrown when the `$localFilePath` (the source file) is already located anywhere
-inside of the target's FAL local storage path. For example inside of :file:`fileadmin/` when using the dafault
+inside of the target's FAL local storage path. For example, inside of :file:`fileadmin/` when using the default
 local storage.


### PR DESCRIPTION
When `GeneralUtility::isFirstPartOfStr($localFilePath, $this->absoluteBasePath)` returns true the exception is thrown.