### PR TITLE
Added an additional space

### DIFF
--- a/Documentation/Exceptions/1438780511.rst
+++ b/Documentation/Exceptions/1438780511.rst
@@ -13,7 +13,7 @@ In v10.4.3 this exception may happen if
 
 * an `internal_type` `file` or `file_reference` is used in combination with type `group`
 
-Using these types has been deprecated in v9.5 and removed in v10. Only `internal_type` `db`or `folder`
+Using these types has been deprecated in v9.5 and removed in v10. Only `internal_type` `db` or `folder`
 are allowed.
 
 If you are using files via the file abstraction layer (FAL) or as inline elements (IRRE), you should use


### PR DESCRIPTION
between db and folder, there is an additional space added. Before the two words were not rendered correctly inside the documenation