### PR TITLE
[TASK] Use documentation rendering container from ghcr.io

### DIFF
--- a/.github/workflows/rendering.yml
+++ b/.github/workflows/rendering.yml
@@ -30,7 +30,7 @@ jobs:
           docker run --rm --user=$(id -u):$(id -g) \
             -v $(pwd):/PROJECT:ro \
             -v $(pwd)/Documentation-GENERATED-temp:/RESULT \
-            t3docs/render-documentation makehtml \
+            ghcr.io/t3docs/render-documentation makehtml \
               -c make_singlehtml 1 \
               -c "/ALL/Menu/mainmenu.sh makehtml -c replace_static_in_html 1 -c make_singlehtml 1 -c jobfile /RESULT/jobfile.json"
 


### PR DESCRIPTION
The documentation team switched from docker hub to the
GitHub Container Registry as home for the documentation
rendering container. It's not available anymore on the
docker hub.

It has been missed to update the GitHub Action workflow
in this repository to use the new rendering container
home as source to pull the image from. That broke the
rendering of the exception documentation.

This change now uses the new complete image name with
the repository to render the documenation again.
