### PR TITLE
Fix rendering.yml

### DIFF
--- a/.github/workflows/rendering.yml
+++ b/.github/workflows/rendering.yml
@@ -30,9 +30,10 @@ jobs:
           docker run --rm --user=$(id -u):$(id -g) \
             -v $(pwd):/PROJECT:ro \
             -v $(pwd)/Documentation-GENERATED-temp:/RESULT \
-            ghcr.io/t3docs/render-documentation makehtml \
+            ghcr.io/t3docs/render-documentation makehtml-no-cache \
               -c make_singlehtml 1 \
-              -c "/ALL/Menu/mainmenu.sh makehtml -c replace_static_in_html 1 -c make_singlehtml 1 -c jobfile /RESULT/jobfile.json"
+              -c replace_static_in_html 1 \
+              -c jobfile /RESULT/jobfile.json
 
       - name: SCP files to production system
         uses: appleboy/scp-action@master


### PR DESCRIPTION
It seems, the wrong 'docker run' command has been in there from the beginning. However, it was a kind
of mispelling that was simply ignored and didn't
cause harm. So it went unnoticed.