### PR TITLE
[BUGFIX] Use correct command to install dependencies

### DIFF
--- a/.github/workflows/exception-codes.yml
+++ b/.github/workflows/exception-codes.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerUpdate
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerInstall
 
       - name: Collect exception code for new releases
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s updateExceptionCodesMissingTags -c


### PR DESCRIPTION
The correct testsuite to install the application dependencies with composer is `-s composerInstall` because a composer.lock file is used.

In the GitHub Action workflow file the not existing `composerUpdate` has been used, which is wrong.

This change now uses the correct script.