### PR TITLE
[BUGFIX] Deal with not available tty on CI environments

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -162,6 +162,14 @@ IMAGE_PREFIX="docker.io/"
 TYPO3_IMAGE_PREFIX="ghcr.io/"
 CONTAINER_INTERACTIVE="-it --init"
 
+IS_CORE_CI=0
+# ENV var "CI" is set by gitlab-ci. We use it here to distinct 'local' and 'CI' environment.
+if [ "${CI}" == "true" ]; then
+    IS_CORE_CI=1
+    # Remove interactive tty for CI runs
+    CONTAINER_INTERACTIVE=""
+fi
+
 IMAGE_PHP="${TYPO3_IMAGE_PREFIX}typo3/core-testing-$(echo "php${PHP_VERSION}" | sed -e 's/\.//'):latest"
 SUFFIX=$(echo $RANDOM)
 NETWORK="typo3-docs-${SUFFIX}"


### PR DESCRIPTION
GitHub Action and others defines a variable "CI" which
can be used to detect a CI environment run. These CI
environments usually don't provide a tty (terminal).

Therefore, we need to respect that environment and remove
the terminal (tty) setting from the docker calls in the
`Build/Scripts/runScript.sh` based on the available CI
env variable.
