### PR TITLE
[BUGFIX] Ensure that auto-commit is working as GitHub Action

### DIFF
--- a/.github/workflows/exception-codes.yml
+++ b/.github/workflows/exception-codes.yml
@@ -28,13 +28,19 @@ jobs:
       - name: Create missing exception code pages
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s createMissingExceptionCodeFiles -c
 
+      - name: List last 10 commits
+        if: ${{ steps.vars.outputs.t3d_has_changes }}
+        shell: bash
+        run: |
+          git log -n 10 --oneline
+
       - name: Check for not pushed commits
         shell: bash
         run: |
           GIT_CURRENT_BRANCH=$(git name-rev --name-only HEAD)
           UNPUSHED_COMMITS=$(git log origin/$GIT_CURRENT_BRANCH..$GIT_CURRENT_BRANCH --oneline)
-          [[ -z "${UNPUSHED_COMMITS}" ]] && echo "::set-output name=t3d_has_changes::false"
-          [[ -n "${UNPUSHED_COMMITS}" ]] && echo "::set-output name=t3d_has_changes::true"
+          [[ -z "${UNPUSHED_COMMITS}" ]] && echo "t3d_has_changes=false" >> $GITHUB_OUTPUT
+          [[ -n "${UNPUSHED_COMMITS}" ]] && echo "t3d_has_changes=true" >> $GITHUB_OUTPUT
 
       - name: Push committed changes
         if: ${{ steps.vars.outputs.t3d_has_changes }}

--- a/Build/app/src/Command/GeneratePagesCommand.php
+++ b/Build/app/src/Command/GeneratePagesCommand.php
@@ -130,12 +130,21 @@ final class GeneratePagesCommand extends Command
         }
         $duration = microtime(true) - $start;
 
+        $hasChanges = $rootRepository->hasChanges();
+
+        $output->writeln(sprintf('COUNT_ADDED...: %s', $countAdded));
+        $output->writeln(sprintf('AUTO_COMMIT...: %s', ($autoCommit ? 'Y' : 'N')));
+        $output->writeln(sprintf('HAS_CHANGES...: %s', ($hasChanges ? 'Y' : 'N')));
+
         if ($countAdded > 0
             && $autoCommit === true
-            && $rootRepository->hasChanges()
+            && $hasChanges
         ) {
             $firstLine = '[TASK] Created missing exception code page(s)';
-            $rootRepository->commit($firstLine);
+            $commit = $rootRepository->commit($firstLine);
+            $output->writeln(sprintf('COMMIT_ID..........: %s', $commit->getId()->toString()));
+            $output->writeln(sprintf('COMMIT_AUTHOR_NAME.: %s', $commit->getAuthorName()));
+            $output->writeln(sprintf('COMMIT_AUTHOR_EMAIL: %s', $commit->getAuthorEmail()));
         } else {
             $output->writeln(
                 $autoCommit === true

--- a/Build/app/src/Git/CustomGitRepository.php
+++ b/Build/app/src/Git/CustomGitRepository.php
@@ -52,7 +52,7 @@ final class CustomGitRepository extends GitRepository
 
     public function userName(): string|null
     {
-        return $this->userEmail ??= $this->detectUserEmail();
+        return $this->userName ??= $this->detectUserName();
     }
 
     public function userEmail(): string|null
@@ -67,22 +67,22 @@ final class CustomGitRepository extends GitRepository
     protected function detectUserName(): string|null
     {
         try {
-            $userEmail = trim($this->runWithoutEnv('config', ['--local', '--get' => 'user.name'])->getOutputAsString());
-            if ($userEmail !== '') {
-                return $userEmail;
+            $userName = trim($this->runWithoutEnv('config', ['--local', '--get' => 'user.name'])->getOutputAsString());
+            if ($userName !== '') {
+                return $userName;
             }
         } catch(GitException) {}
 
         try {
-            $userEmail = trim($this->runWithoutEnv('config', ['--global', '--get' => 'user.name'])->getOutputAsString());
-            if ($userEmail !== '') {
-                return $userEmail;
+            $userName = trim($this->runWithoutEnv('config', ['--global', '--get' => 'user.name'])->getOutputAsString());
+            if ($userName !== '') {
+                return $userName;
             }
         } catch(GitException) {}
 
-        $userEmail = trim((string)getenv('GIT_USER_NAME') ?? '');
-        if ($userEmail !== '') {
-            return $userEmail;
+        $userName = trim((string)getenv('GIT_USER_NAME') ?? '');
+        if ($userName !== '') {
+            return $userName;
         }
 
         return $this->defaultUserName ?? 'unknown';

--- a/Build/app/src/Service/FetcherService.php
+++ b/Build/app/src/Service/FetcherService.php
@@ -222,15 +222,22 @@ class FetcherService
             }
         }
 
+        $hasChanges = $this->rootRepository->hasChanges();
+        $this->output->writeln(sprintf('COUNT_ADDED...: %s', $countAdded));
+        $this->output->writeln(sprintf('AUTO_COMMIT...: %s', ($this->autoCommit ? 'Y' : 'N')));
+        $this->output->writeln(sprintf('HAS_CHANGES...: %s', ($hasChanges ? 'Y' : 'N')));
+
         if ($this->autoCommit === true
-            && $this->rootRepository->hasChanges()
+            && $hasChanges
             && $countAdded > 0
         ) {
             $firstLine = ($this->mode === FetchMode::Missing)
                 ? '[TASK] Added missing release exception codes'
                 : '[TASK] Rebuild exception codes for all releases';
-            $rootRepository->commit($firstLine);
-
+            $commit = $rootRepository->commit($firstLine);
+            $this->output->writeln(sprintf('COMMIT_ID..........: %s', $commit->getId()->toString()));
+            $this->output->writeln(sprintf('COMMIT_AUTHOR_NAME.: %s', $commit->getAuthorName()));
+            $this->output->writeln(sprintf('COMMIT_AUTHOR_EMAIL: %s', $commit->getAuthorEmail()));
         } else {
             $this->output->writeln(
                 $this->autoCommit === true
@@ -249,13 +256,6 @@ class FetcherService
         );
 
         chdir($currentDirectory);
-
-        if ($this->autoCommit === true && $rootRepository->hasChanges()) {
-            throw new \RuntimeException(
-                'Changes left in repository after committing exception code release collections.',
-                1696777795
-            );
-        }
     }
 
     protected function exceptionJsonFilePathForTag(string $tag): string


### PR DESCRIPTION
* Removed additional clean check as unpushed commits are
  returned as `has changes` and therefore not feasonable
  to check.
* Added additional output regarding the commit creation
  for both commands.
* Ensure that the git user name is correctly determined
  and not using the email as name value.
* Using `$GITHUB_OUTPUT` output redirection instead of
  depreated `::set-output`.
