### PR TITLE
[BUGFIX] Avoid rendering warnings

### DIFF
--- a/Documentation/Exceptions/1546632293.rst
+++ b/Documentation/Exceptions/1546632293.rst
@@ -33,7 +33,7 @@ Add explicitly a default value:
 ::
 
    protected ?Cart $cart = null;
-   
+
 `Read more information on this behaviour <https://blog.reelworx.at/detail/typo3-extbase-and-type-annotations-with-php-74/>`__.
 
 TYPO3 11.5.31 - 2023-09-29
@@ -45,6 +45,7 @@ Situation
 When validating a controller's argument, the following exception is thrown:
 
 .. code-block:: text
+
    #1546632293 RuntimeException Could not get value of property "Site\Site\Domain\Model\Booking::startdate",
    make sure the property is either public or has a getter getStartdate(), a hasser hasStartdate() or an isser isStartdate().
 

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -45,7 +45,7 @@ t3tca          = https://docs.typo3.org/m/typo3/reference-tca/main/en-us/
 # t3tsconfig     = https://docs.typo3.org/m/typo3/reference-tsconfig/main/en-us/
 # t3tsref        = https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/
 # t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/main/en-us/
-# t3viewhelper   = https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/
+t3viewhelper   = https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/
 # t3upgrade      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
 
 # TYPO3 system extensions


### PR DESCRIPTION
    ./Documentation/Exceptions/1546632293.rst:47: ERROR: Error in "code-block" directive: maximum 1 argument(s) allowed, 29 supplied.

    ./Documentation/Exceptions/1639819269.rst:16: WARNING: undefined label: t3viewhelper:typo3-fluid-uri-page