### PR TITLE
fix link to trouble shooting page

### DIFF
--- a/Documentation/Exceptions/1533818591.rst
+++ b/Documentation/Exceptions/1533818591.rst
@@ -35,8 +35,7 @@ system is then deployed to a system that does not support *argon2i*.
 Solutions
 =========
 
-Please see :ref:`Password hashing troubleshooting
-<t3coreapi:password-hashing_troubleshooting>`.
+Please see :ref:`Password hashing troubleshooting <t3coreapi:password-hashing\_troubleshooting>`.
 
 More information
 ================


### PR DESCRIPTION
The link does not work.

See

https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#external-hyperlink-targets

https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/PasswordHashing/Troubleshooting.html#troubleshooting