### PR TITLE
Link to talk.typo3.org instead of Slack in Exception note

### DIFF
--- a/Documentation/If-you-encounter-this-exception.rst.txt
+++ b/Documentation/If-you-encounter-this-exception.rst.txt
@@ -8,8 +8,8 @@
    resolved it.
 
    General TYPO3 troubleshooting tips can be found in the section
-   "Troubleshooting" of the menu, and live support is available in the
-   `TYPO3 Slack channel <https://typo3.slack.com>`__ #typo3-cms. (See `How to get your TYPO3 Slack account <https://typo3.org/community/meet/chat-slack>`__.)
+   "Troubleshooting" of the menu. You can also ask questions and receive support in the
+   `"TYPO3 Questions" category on talk.typo3.org <https://talk.typo3.org/c/typo3-questions/>`__.
 
    To add your experience, click "Edit on GitHub" above and follow the
    :ref:`"Edit on GitHub" workflow <h2document:docs-contribute-github-method>`.

--- a/Documentation/If-you-encounter-this-exception.rst.txt
+++ b/Documentation/If-you-encounter-this-exception.rst.txt
@@ -8,8 +8,8 @@
    resolved it.
 
    General TYPO3 troubleshooting tips can be found in the section
-   "Troubleshooting" of the menu. You can also ask questions and receive support in the
-   `"TYPO3 Questions" category on talk.typo3.org <https://talk.typo3.org/c/typo3-questions/>`__.
+   *Troubleshooting* section in the menu. You can also ask questions and receive support in the
+   `TYPO3 Questions category on talk.typo3.org <https://talk.typo3.org/c/typo3-questions/>`__.
 
    To add your experience, click "Edit on GitHub" above and follow the
    :ref:`"Edit on GitHub" workflow <h2document:docs-contribute-github-method>`.


### PR DESCRIPTION
This adjusts the part of the exception troubleshooting note to now say:

> [...]
>
> General TYPO3 troubleshooting tips can be found in the section "Troubleshooting" of the menu. You can also ask questions and receive support in the ["TYPO3 Questions" category on talk.typo3.org](https://talk.typo3.org/c/typo3-questions/).
>
> [...]

This decision was made by @mabolek, since we want to get people to post their questions on https://talk.typo3.org primarily, so they are publicly searchable and indexable. This leads to less repeatedly asked questions, as happening in Slack (or other places that rely on real-time communications).

**Side question that I was not able to solve myself:** Is it possible to write in italics inside a link? @mabolek wanted to have text references in italics (e.g. _TYPO3 Questions_ instead of "TYPO3 Questions"), but I was not able to get that to work with basic ReST markup.