### PR TITLE
Handling of reverseproxy problems

### DIFF
--- a/Documentation/Exceptions/1588095936.rst
+++ b/Documentation/Exceptions/1588095936.rst
@@ -11,4 +11,7 @@ first time. No login, normally automatically logged in by a service.
 Maybe old temporary files or other old data. Clear InstallTool Cache
 solve the problem.
 
-The error might also occur due to a very strict referrer-policy of your webserver. For instance, if you set it to 'Header set Referrer-Policy "strict-origin"' in your Apache server, you will see this page after trying to login to the backend.
+The error might also occur due to:
+a. A very strict referrer-policy of your webserver. For instance, if you set it to 'Header set Referrer-Policy "strict-origin"' in your Apache server, you will see this page after trying to login to the backend.
+or
+b. A reverseproxy in front of typo3 (like varnish or haproxy). To overcome that configure the proxy settings in [SYS][reverseProxy*]


### PR DESCRIPTION
Based on information found here:
https://stackoverflow.com/questions/63869637/unable-to-login-to-new-typo3-10-4-8

adding:
```
        'reverseProxyIP' => '*',
        'reverseProxySSL' => '*',
```

to my typo3conf/system/settings.php file solved my problem of 
"Invalid referrer for /main"