### PR TITLE
exception in routing with TYPO3 14 and not activated tt_board

### DIFF
--- a/Documentation/Exceptions/1661540376.rst
+++ b/Documentation/Exceptions/1661540376.rst
@@ -7,18 +7,17 @@ TYPO3 Exception 1661540376
 .. include:: /If-you-encounter-this-exception.rst.txt
 
 
-..
-   TYPO3 [version] - [date of report]
-   ==================================
+TYPO3 [version] - [date of report]
+==================================
 
-   Installation Overview
-   ---------------------
+Installation Overview
+---------------------
 
-   TYPO3 14.3 with not acitvated extension tt_board and records of it. The routing contains a config.yaml which contains tt_board records:
+TYPO3 14.3 with not acitvated extension tt_board and records of it. The routing contains a config.yaml which contains tt_board records:
 
 ..  code-block:: yaml
     :caption: EXT:tt_board/config.yaml
-
+    
     TtBoardList:
        type: Plugin
        routePath: '/boardl/{uid}'
@@ -29,10 +28,10 @@ TYPO3 Exception 1661540376
            tableName: tt_board
            routeFieldName: slug
 
-   The Issue
-   ---------
+The Issue
+---------
 
-   The front end with speaking url shows this exception:
+The front end with speaking url shows this exception:
 
 
 **#1661540376 TYPO3\CMS\Core\Schema\Exception\UndefinedSchemaException**
@@ -41,20 +40,20 @@ No TCA schema exists for the name "tt_board".
 /path/typo3_src-14.3.0/typo3/sysext/core/Classes/Schema/SchemaCollection.php:76:
 
 ..  code-block:: php
-    :caption: EXT:tt_board/config.yaml
+:caption: EXT:tt_board/config.yaml
 
-     public function get(string $schemaName): TcaSchema
-     {
-        if (!$this->has($schemaName)) {
-            throw new UndefinedSchemaException('No TCA schema exists for the name "' . $schemaName . '".', 1661540376);
-        }
-        if (str_contains($schemaName, '.')) {
-            [$mainSchema, $subSchema] = explode('.', $schemaName, 2);
-            return $this->get($mainSchema)->getSubSchema($subSchema);
+ public function get(string $schemaName): TcaSchema
+ {
+    if (!$this->has($schemaName)) {
+        throw new UndefinedSchemaException('No TCA schema exists for the name "' . $schemaName . '".', 1661540376);
+    }
+    if (str_contains($schemaName, '.')) {
+        [$mainSchema, $subSchema] = explode('.', $schemaName, 2);
+        return $this->get($mainSchema)->getSubSchema($subSchema);
 
 
-   Solution
-   --------
+Solution
+--------
 
-    Activate the extension tt_board which contains the TCA for the table tt_board.
+Activate the extension tt_board which contains the TCA for the table tt_board.
 

--- a/Documentation/Exceptions/1661540376.rst
+++ b/Documentation/Exceptions/1661540376.rst
@@ -8,24 +8,53 @@ TYPO3 Exception 1661540376
 
 
 ..
-   TYPO3 [version] - [date of report]
-   ==================================
+   TYPO3 14.3 - [date of report]
+   =============================
 
    Installation Overview
    ---------------------
 
-   Provide as much information about your installation of TYPO3
-   including its version number and any other information that
-   you think will be relevant to other users who encounter the same issue.
+   TYPO3 14.3 with not acitvated extension tt_board and records of it. The routing contains a config.yaml which contains tt_board records:
+
+..  code-block:: yaml
+    :caption: EXT:tt_board/config.yaml
+
+    TtBoardList:
+       type: Plugin
+       routePath: '/boardl/{uid}'
+       namespace: tt_board_list
+       aspects:
+         uid:
+           type: PersistedAliasMapper
+           tableName: tt_board
+           routeFieldName: slug
 
    The Issue
    ---------
 
-   Detail each of the steps or changes that took place leading up to the
-   issue occurring.
+   The front end with speaking url shows this exception:
+
+
+**#1661540376 TYPO3\CMS\Core\Schema\Exception\UndefinedSchemaException**
+No TCA schema exists for the name "tt_board".
+
+/path/typo3_src-14.3.0/typo3/sysext/core/Classes/Schema/SchemaCollection.php:76:
+
+..  code-block:: php
+    :caption: EXT:tt_board/config.yaml
+
+     public function get(string $schemaName): TcaSchema
+     {
+        if (!$this->has($schemaName)) {
+            throw new UndefinedSchemaException('No TCA schema exists for the name "' . $schemaName . '".', 1661540376);
+        }
+        if (str_contains($schemaName, '.')) {
+            [$mainSchema, $subSchema] = explode('.', $schemaName, 2);
+            return $this->get($mainSchema)->getSubSchema($subSchema);
+
 
    Solution
    --------
 
-   Did you resolve the issue? List the steps or changes made that resolved the
-   issue.
+    Activate the extension tt_board which contains the TCA for the table tt_board.
+

--- a/Documentation/Exceptions/1661540376.rst
+++ b/Documentation/Exceptions/1661540376.rst
@@ -8,8 +8,8 @@ TYPO3 Exception 1661540376
 
 
 ..
-   TYPO3 14.3 - [date of report]
-   =============================
+   TYPO3 [version] - [date of report]
+   ==================================
 
    Installation Overview
    ---------------------


### PR DESCRIPTION
Created exception documentation for TYPO3 14.3 with detailed installation and issue description.