### PR TITLE
fix example code for FlexForm

### DIFF
--- a/Documentation/Exceptions/1480765571.rst
+++ b/Documentation/Exceptions/1480765571.rst
@@ -36,7 +36,7 @@ but forget the prefix `FILE:`:
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
         '*',
         'EXT:my_extension/Resources/Private/FlexForm/MyFlexForm.xml',
-        'textpic'
+        'myextension_textpic'
     );
 
     /**
@@ -44,6 +44,6 @@ but forget the prefix `FILE:`:
      */
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
         '*',
-        'FILE:EXT:my_extension/Resources/Private/FlexForm/MyFlexForm.xml',
-        'textpic'
+        'FILE:EXT:my_extension/Configuration/FlexForms/MyFlexForm.xml',
+        'myextension_textpic'
     );


### PR DESCRIPTION
The path and the plugin signature in the examples shall be correct.