### PR TITLE
Clarify image/file tag rendering in content-blocks

### DIFF
--- a/Documentation/Exceptions/1509741912.rst
+++ b/Documentation/Exceptions/1509741912.rst
@@ -32,3 +32,26 @@ Message is shown:
       #1509741912: Supplied file object
       type TYPO3\CMS\Core\Resource\ProcessedFile for must be
       File or FileReference.
+
+Unable to render image tag in "tt_content:xxxx": Supplied file must be File or FileReference, TYPO3\\CMS\\Core\\Resource\\Collection\\LazyFileReferenceCollection given
+=======================================================================================================================================================================
+
+This message appears with content-blocks if you try display an image (or a file) directly with for example:
+
+::
+
+    <f:image image="{data.image}" width="42" maxHeight="48" />
+
+images and files are collections with content-blocks, you need to use a <f:for> loop to display them: 
+
+::
+
+    <f:for each="{data.image}" as="image">
+        <f:image image="{image}" width="42" maxHeight="48" />
+    </f:for>
+
+or if you're sure the file exists, you can also use:
+
+::
+
+    <f:image image="{data.image.0}" width="42" maxHeight="48" />


### PR DESCRIPTION
Added clarification on rendering image/file tags in content-blocks and provided examples for correct usage.